### PR TITLE
feat: add conditional headers/params with enabledWhen expression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Claude Instructions for RestPie
+
+This file contains coding conventions and rules for Claude to follow when working on this project.
+
+## UI Component Conventions
+
+### Modal Button Styling
+
+When creating or modifying modals, footer buttons must follow this pattern:
+
+1. Wrap all buttons in a single `<div>` inside `<ModalFooter>` to align them to the right side
+2. All buttons should use `className="btn"` (not `btn--super-compact` or other variants)
+3. The secondary/cancel action button comes first, followed by the primary action button
+
+**Example:**
+```tsx
+<ModalFooter>
+  <div>
+    <button className="btn" onClick={handleCancel}>
+      Cancel
+    </button>
+    <button className="btn" onClick={handleSave}>
+      Save
+    </button>
+  </div>
+</ModalFooter>
+```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ I have removed user login, tracking, analytics, etc, from Insomnia so it is now 
 
 ## New Features
 
+- **Conditional headers and query parameters** - Include or exclude headers and parameters based on JavaScript expressions evaluated against environment variables (e.g., `includeAuth === true`).
 - **Comment support in request body** - Toggle line comments with Cmd+/ (Mac) or Ctrl+/ (Windows/Linux). Comments are preserved in the editor but automatically stripped before sending requests.
 - **Sidebar request name tooltips** - Hover over truncated request names to see the full name.
 

--- a/packages/restpie/src/common/render.ts
+++ b/packages/restpie/src/common/render.ts
@@ -534,7 +534,7 @@ export async function getRenderedRequestAndContext(
   const renderedCookieJar = renderResult._cookieJar;
   renderedRequest.description = await render(description, renderContext, null, KEEP_ON_ERROR);
   const suppressUserAgent = request.headers.some(h => h.name.toLowerCase() === 'user-agent' && h.disabled === true);
-  
+
   // Helper to check if a param/header should be included
   // - If enabledWhen is set: include when condition is TRUE
   // - Otherwise: include if not disabled
@@ -544,7 +544,7 @@ export async function getRenderedRequestAndContext(
     }
     return !p.disabled;
   };
-  
+
   // Filter to only include enabled params
   renderedRequest.parameters = renderedRequest.parameters.filter(p => shouldInclude(p));
   // Filter to only include enabled headers

--- a/packages/restpie/src/common/render.ts
+++ b/packages/restpie/src/common/render.ts
@@ -56,6 +56,28 @@ export type HandleGetRenderContext = () => Promise<RenderContextAndKeys>;
 
 export type HandleRender = <T>(object: T, contextCacheKey?: string | null) => Promise<T>;
 
+/**
+ * Evaluate a JavaScript expression against a context object to determine
+ * if a header/parameter should be included.
+ * @param expression - JavaScript expression string (e.g., "env === 'production'")
+ * @param context - The render context containing environment variables
+ * @returns true if the expression evaluates to truthy (meaning item should be included)
+ */
+export function evaluateCondition(
+  expression: string | undefined,
+  context: Record<string, any>
+): boolean {
+  if (!expression?.trim()) return false;
+  try {
+    // Create a safe function with context variables in scope
+    const fn = new Function(...Object.keys(context), `return (${expression})`);
+    return Boolean(fn(...Object.values(context)));
+  } catch (err) {
+    console.warn(`Failed to evaluate condition: ${expression}`, err);
+    return false;
+  }
+}
+
 export async function buildRenderContext(
   {
     ancestors,
@@ -512,14 +534,25 @@ export async function getRenderedRequestAndContext(
   const renderedCookieJar = renderResult._cookieJar;
   renderedRequest.description = await render(description, renderContext, null, KEEP_ON_ERROR);
   const suppressUserAgent = request.headers.some(h => h.name.toLowerCase() === 'user-agent' && h.disabled === true);
-  // Remove disabled params
-  renderedRequest.parameters = renderedRequest.parameters.filter(p => !p.disabled);
-  // Remove disabled headers
-  renderedRequest.headers = renderedRequest.headers.filter(p => !p.disabled);
+  
+  // Helper to check if a param/header should be included
+  // - If enabledWhen is set: include when condition is TRUE
+  // - Otherwise: include if not disabled
+  const shouldInclude = (p: { disabled?: boolean; enabledWhen?: string }) => {
+    if (p.enabledWhen) {
+      return evaluateCondition(p.enabledWhen, renderContext);
+    }
+    return !p.disabled;
+  };
+  
+  // Filter to only include enabled params
+  renderedRequest.parameters = renderedRequest.parameters.filter(p => shouldInclude(p));
+  // Filter to only include enabled headers
+  renderedRequest.headers = renderedRequest.headers.filter(p => shouldInclude(p));
 
-  // Remove disabled body params
+  // Filter body params
   if (renderedRequest.body && Array.isArray(renderedRequest.body.params)) {
-    renderedRequest.body.params = renderedRequest.body.params.filter(p => !p.disabled);
+    renderedRequest.body.params = renderedRequest.body.params.filter(p => shouldInclude(p));
   }
 
   // Remove disabled authentication

--- a/packages/restpie/src/models/grpc-request.ts
+++ b/packages/restpie/src/models/grpc-request.ts
@@ -16,6 +16,7 @@ export interface GrpcRequestHeader {
   value: string;
   description?: string;
   disabled?: boolean;
+  enabledWhen?: string;  // JS expression - include when TRUE
 }
 
 interface BaseGrpcRequest {

--- a/packages/restpie/src/models/request.ts
+++ b/packages/restpie/src/models/request.ts
@@ -61,12 +61,14 @@ export interface RequestHeader {
   value: string;
   description?: string;
   disabled?: boolean;
+  enabledWhen?: string;  // JS expression - include when TRUE
 }
 
 export interface RequestParameter {
   name: string;
   value: string;
   disabled?: boolean;
+  enabledWhen?: string;  // JS expression - include when TRUE
   id?: string;
   fileName?: string;
 }
@@ -75,6 +77,7 @@ export interface RequestSegment {
   name: string;
   value: string;
   disabled?: boolean;
+  enabledWhen?: string;  // JS expression - include when TRUE
   id?: string;
   fileName?: string;
 }
@@ -84,6 +87,7 @@ export interface RequestBodyParameter {
   value: string;
   description?: string;
   disabled?: boolean;
+  enabledWhen?: string;  // JS expression - include when TRUE
   multiline?: string;
   id?: string;
   fileName?: string;

--- a/packages/restpie/src/ui/components/modals/condition-editor-modal.tsx
+++ b/packages/restpie/src/ui/components/modals/condition-editor-modal.tsx
@@ -1,0 +1,93 @@
+import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+
+import { Modal, type ModalHandle, ModalProps } from '../base/modal';
+import { ModalBody } from '../base/modal-body';
+import { ModalFooter } from '../base/modal-footer';
+import { ModalHeader } from '../base/modal-header';
+
+interface ConditionEditorModalOptions {
+  title: string;
+  defaultValue: string;
+  onSave: (value: string) => void;
+  onClear: () => void;
+}
+
+export interface ConditionEditorModalHandle {
+  show: (options: ConditionEditorModalOptions) => void;
+  hide: () => void;
+}
+
+export const ConditionEditorModal = forwardRef<ConditionEditorModalHandle, ModalProps>((_, ref) => {
+  const modalRef = useRef<ModalHandle>(null);
+  const [state, setState] = useState<ConditionEditorModalOptions>({
+    title: 'Condition',
+    defaultValue: '',
+    onSave: () => { },
+    onClear: () => { },
+  });
+  const [value, setValue] = useState('');
+
+  useImperativeHandle(ref, () => ({
+    hide: () => {
+      modalRef.current?.hide();
+    },
+    show: options => {
+      setState(options);
+      setValue(options.defaultValue || '');
+      modalRef.current?.show();
+    },
+  }), []);
+
+  const {
+    title,
+    onSave,
+    onClear,
+  } = state;
+
+  return (
+    <Modal ref={modalRef}>
+      <ModalHeader>{title}</ModalHeader>
+      <ModalBody className="pad">
+        <div className="form-control form-control--outlined">
+          <label>
+            Include Condition
+            <span className="faint txt-sm space-left">
+              (JavaScript expression - include when TRUE)
+            </span>
+          </label>
+          <input
+            type="text"
+            placeholder="e.g., env === 'production' || includeAuth === true"
+            value={value}
+            onChange={e => setValue(e.target.value)}
+            style={{ width: '100%', fontFamily: 'monospace' }}
+          />
+        </div>
+        <p className="faint txt-sm pad-top-sm">
+          You can reference variables from the currently selected environment, e.g. <code>includeAuth === true</code>
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <button
+          className="btn btn--super-compact"
+          onClick={() => {
+            onClear();
+            modalRef.current?.hide();
+          }}
+        >
+          Clear Condition
+        </button>
+        <button
+          className="btn"
+          onClick={() => {
+            onSave(value);
+            modalRef.current?.hide();
+          }}
+        >
+          Save
+        </button>
+      </ModalFooter>
+    </Modal>
+  );
+});
+ConditionEditorModal.displayName = 'ConditionEditorModal';

--- a/packages/restpie/src/ui/components/modals/condition-editor-modal.tsx
+++ b/packages/restpie/src/ui/components/modals/condition-editor-modal.tsx
@@ -68,24 +68,26 @@ export const ConditionEditorModal = forwardRef<ConditionEditorModalHandle, Modal
         </p>
       </ModalBody>
       <ModalFooter>
-        <button
-          className="btn btn--super-compact"
-          onClick={() => {
-            onClear();
-            modalRef.current?.hide();
-          }}
-        >
-          Clear Condition
-        </button>
-        <button
-          className="btn"
-          onClick={() => {
-            onSave(value);
-            modalRef.current?.hide();
-          }}
-        >
-          Save
-        </button>
+        <div>
+          <button
+            className="btn"
+            onClick={() => {
+              onClear();
+              modalRef.current?.hide();
+            }}
+          >
+            Clear Condition
+          </button>
+          <button
+            className="btn"
+            onClick={() => {
+              onSave(value);
+              modalRef.current?.hide();
+            }}
+          >
+            Save
+          </button>
+        </div>
       </ModalFooter>
     </Modal>
   );

--- a/packages/restpie/src/ui/components/modals/select-modal.tsx
+++ b/packages/restpie/src/ui/components/modals/select-modal.tsx
@@ -29,12 +29,14 @@ export const SelectModal = forwardRef<SelectModalHandle, ModalProps>((_, ref) =>
     title: null,
     value: null,
   });
+  const [isLoading, setIsLoading] = useState(false);
 
   useImperativeHandle(ref, () => ({
     hide: () => {
       modalRef.current?.hide();
     },
     show: options => {
+      setIsLoading(false);
       setState(options);
       modalRef.current?.show();
     },
@@ -59,12 +61,24 @@ export const SelectModal = forwardRef<SelectModalHandle, ModalProps>((_, ref) =>
       <ModalFooter>
         <button
           className="btn"
-          onClick={() => {
+          disabled={isLoading}
+          onClick={async () => {
+            if (onDone) {
+              setIsLoading(true);
+              try {
+                await onDone(value);
+              } finally {
+                setIsLoading(false);
+              }
+            }
             modalRef.current?.hide();
-            onDone?.(value);
           }}
         >
-          Done
+          {isLoading ? (
+            <><i className="fa fa-spinner fa-spin" /> Exporting...</>
+          ) : (
+            'Done'
+          )}
         </button>
       </ModalFooter>
     </Modal>

--- a/packages/restpie/src/ui/components/rendered-query-string.tsx
+++ b/packages/restpie/src/ui/components/rendered-query-string.tsx
@@ -41,7 +41,7 @@ export const RenderedQueryString: FC<Props> = ({ request }) => {
   useAsync(async () => {
     // Get render context to evaluate enabledWhen conditions
     const { context } = await handleGetRenderContext();
-    
+
     // Filter parameters: include if (no enabledWhen and not disabled) OR (enabledWhen evaluates to true)
     const shouldInclude = (p: { disabled?: boolean; enabledWhen?: string }) => {
       if (p.enabledWhen) {
@@ -49,7 +49,7 @@ export const RenderedQueryString: FC<Props> = ({ request }) => {
       }
       return !p.disabled;
     };
-    
+
     const enabledParameters = request.parameters.filter(shouldInclude);
     const enabledSeg = request.segmentParams.filter(shouldInclude);
     try {

--- a/packages/restpie/src/ui/routes/modals.tsx
+++ b/packages/restpie/src/ui/routes/modals.tsx
@@ -7,6 +7,7 @@ import { AddKeyCombinationModal } from '../components/modals/add-key-combination
 import { AlertModal } from '../components/modals/alert-modal';
 import { AskModal } from '../components/modals/ask-modal';
 import { CodePromptModal } from '../components/modals/code-prompt-modal';
+import { ConditionEditorModal } from '../components/modals/condition-editor-modal';
 import { EnvironmentEditModal } from '../components/modals/environment-edit-modal';
 import { ErrorModal } from '../components/modals/error-modal';
 import { FilterHelpModal } from '../components/modals/filter-help-modal';
@@ -55,6 +56,9 @@ const Modals: FC = () => {
 
         <CodePromptModal
           ref={instance => registerModal(instance, 'CodePromptModal')}
+        />
+        <ConditionEditorModal
+          ref={instance => registerModal(instance, 'ConditionEditorModal')}
         />
 
         {activeWorkspace ? (


### PR DESCRIPTION
- Add enabledWhen field to RequestHeader, RequestParameter, RequestBodyParameter, RequestSegment, and GrpcRequestHeader interfaces
- Add evaluateCondition() helper to evaluate JavaScript expressions against environment context
- Filter headers/params based on enabledWhen condition in getRenderedRequestAndContext()
- Update RenderedQueryString to filter URL preview based on enabledWhen
- Add ConditionEditorModal for editing conditions
- Update KeyValueEditor row with dropdown for inclusion mode (Always Included/Excluded/Conditional)
- Add unit tests for evaluateCondition() and filtering logic

<!--
Please open an [Issue](https://github.com/ArchGPT/insomnium/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
